### PR TITLE
Vercel fix

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+    "version": 2,
+    "routes": [
+        {
+            "src": "/.*",
+            "dest": "index.html"
+        }
+    ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,9 @@
     "version": 2,
     "routes": [
         {
+            "handle": "filesystem"
+        },
+        {
             "src": "/.*",
             "dest": "index.html"
         }


### PR DESCRIPTION
Access a link directly such as https://ghostdev.xyz/contact would result in a 404, this fixes that